### PR TITLE
Change github pages link in README to *.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Audio/MIDI Demo List
 
-This is where the W3C Audio WG used to keep a list of [demos or interesting applications of the Web Audio/MIDI APIs](http://webaudio.github.com/demo-list/).
+This is where the W3C Audio WG used to keep a list of [demos or interesting applications of the Web Audio/MIDI APIs](http://webaudio.github.io/demo-list/).
 
 
 ## Contributing


### PR DESCRIPTION
As of 15th April 2021, github no longer support github pages redirects on *.github.com
https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/